### PR TITLE
multi_json dependency updated

### DIFF
--- a/omniauth-37signals.gemspec
+++ b/omniauth-37signals.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'omniauth', '~> 1.0'
   gem.add_dependency 'omniauth-oauth2', '~> 1.0'
-  gem.add_dependency 'multi_json', '~> 1.0.3'
+  gem.add_dependency 'multi_json', '>= 1.0.0', '<= 1.1.0'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
Because rails 3.2.1 requires multi_json 1.1.0
