### PR TITLE
Allow multi_json 1.5.0

### DIFF
--- a/omniauth-37signals.gemspec
+++ b/omniauth-37signals.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'omniauth', '~> 1.0'
   gem.add_dependency 'omniauth-oauth2', '~> 1.0'
-  gem.add_dependency 'multi_json', '>= 1.0.0', '<= 1.3.6'
+  gem.add_dependency 'multi_json', '>= 1.0.0', '<= 1.5.0'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
```
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/..
Bundler could not find compatible versions for gem "multi_json":
  In Gemfile:
    omniauth-37signals (>= 0) ruby depends on
      multi_json (~> 1.0.3) ruby

    uglifier (>= 1.0.3) ruby depends on
      multi_json (1.5.0)
```

The same 2 specs fails before and after the change.
